### PR TITLE
fix: harden BusPublicationWatcher device loop against silent freezes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `BusPublicationWatcher._device_loop` no longer dies silently on an unhandled exception during device reconciliation (e.g. while tearing down a node that just went dark). A failing tick is now logged and retried on the next poll instead of permanently freezing device tracking for the rest of the watch session while the watcher still reports itself as running.
 * `BusPublicationWatcher` now notifies `on_state_changed` when a node departs, not just when one appears or finishes setup, so push-based consumers see departures immediately instead of waiting for their next unrelated update.
+* Fixed an `AttributeError: 'Heartbeat_1_0' object has no attribute 'value'` that could silently kill a device's watch tasks. `pycyphal` shares one `Subscriber` implementation per subject-ID across the whole presentation layer regardless of the requested dtype, so subscribing to the heartbeat subject as `Unstructured_1` (to log heartbeat traffic outside the publication catalog) actually returned the typed `Heartbeat_1_0` subscriber already created by `Client`'s `NodeTracker`. The heartbeat subject is now subscribed with its real type, and `_unstructured_loop` falls back to best-effort serialization instead of crashing if it ever receives an unexpectedly-typed message again.
 
 ## [0.7.1] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-* _Nothing yet._
+* `BusPublicationWatcher._device_loop` no longer dies silently on an unhandled exception during device reconciliation (e.g. while tearing down a node that just went dark). A failing tick is now logged and retried on the next poll instead of permanently freezing device tracking for the rest of the watch session while the watcher still reports itself as running.
+* `BusPublicationWatcher` now notifies `on_state_changed` when a node departs, not just when one appears or finishes setup, so push-based consumers see departures immediately instead of waiting for their next unrelated update.
 
 ## [0.7.1] - 2026-06-23
 

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -279,37 +279,52 @@ class BusPublicationWatcher:
     async def _device_loop(self) -> None:
         """Poll node tracker and reconcile watched devices with the current bus."""
         while not self._stop_event.is_set():
-            entries = dict(self.client.node_tracker.registry)
-            current_ids = set(entries)
-            known_ids = set(self.devices)
-
-            # New nodes: register immediately, then discover publications in parallel.
-            for node_id in current_ids - known_ids:
-                if node_id == self.client.node.id:
-                    continue
-                entry = entries[node_id]
-                device_info = self._serialize_node_entry(node_id, entry)
-                async with self._lock:
-                    self.devices[node_id] = DeviceWatchState(node_id=node_id, device_info=device_info)
-                self._notify_state_changed()
-                self._start_device_setup(node_id)
-
-            # Departed nodes: cancel in-flight setup, subscribers, and cached state.
-            for node_id in known_ids - current_ids:
-                await self._cancel_device_setup(node_id)
-                async with self._lock:
-                    state = self.devices.pop(node_id, None)
-                if state is not None:
-                    await self._teardown_device(state)
-                self.unknown_ports.pop(node_id, None)
-                self._drop_port_message_history(node_id)
-
-            # Refresh heartbeat/name metadata for nodes still online.
-            for node_id, entry in entries.items():
-                if node_id in self.devices:
-                    self.devices[node_id].device_info = self._serialize_node_entry(node_id, entry)
+            try:
+                await self._reconcile_devices_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Never let a single bad reconciliation tick (e.g. a transient
+                # error while tearing down a device that just went dark) kill
+                # the whole loop — that would silently freeze device tracking
+                # for the rest of the session even though the watcher still
+                # reports itself as running.
+                LOGGER.exception("Monitor device loop tick failed; will retry")
 
             await asyncio.sleep(0.5)
+
+    async def _reconcile_devices_once(self) -> None:
+        """Diff the node tracker registry against watched devices for one tick."""
+        entries = dict(self.client.node_tracker.registry)
+        current_ids = set(entries)
+        known_ids = set(self.devices)
+
+        # New nodes: register immediately, then discover publications in parallel.
+        for node_id in current_ids - known_ids:
+            if node_id == self.client.node.id:
+                continue
+            entry = entries[node_id]
+            device_info = self._serialize_node_entry(node_id, entry)
+            async with self._lock:
+                self.devices[node_id] = DeviceWatchState(node_id=node_id, device_info=device_info)
+            self._notify_state_changed()
+            self._start_device_setup(node_id)
+
+        # Departed nodes: cancel in-flight setup, subscribers, and cached state.
+        for node_id in known_ids - current_ids:
+            await self._cancel_device_setup(node_id)
+            async with self._lock:
+                state = self.devices.pop(node_id, None)
+            if state is not None:
+                await self._teardown_device(state)
+            self.unknown_ports.pop(node_id, None)
+            self._drop_port_message_history(node_id)
+            self._notify_state_changed()
+
+        # Refresh heartbeat/name metadata for nodes still online.
+        for node_id, entry in entries.items():
+            if node_id in self.devices:
+                self.devices[node_id].device_info = self._serialize_node_entry(node_id, entry)
 
     def _start_device_setup(self, node_id: int) -> None:
         existing = self._setup_tasks.get(node_id)

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -478,12 +478,48 @@ class BusPublicationWatcher:
         if subject_id in state.unstructured_tasks:
             return
 
-        subscriber = self.client.node.make_subscriber(uavcan.primitive.Unstructured_1, subject_id)
-        task = asyncio.create_task(
-            self._unstructured_loop(state, subject_id, subscriber),
-            name=f"pubwatch-unstructured-{state.node_id}-{subject_id}",
-        )
+        if subject_id == HEARTBEAT_SUBJECT_ID:
+            # pycyphal shares one Subscriber implementation per subject-ID across the whole
+            # presentation layer, regardless of the dtype requested by a given caller
+            # (`Presentation.make_subscriber` keys its registry by subject-ID only). The
+            # heartbeat subject already has an active `uavcan.node.Heartbeat_1_0` subscriber
+            # from `Client`'s `NodeTracker`, so requesting `Unstructured_1` here would silently
+            # hand back that same typed subscriber instead of raw bytes, and accessing
+            # `message.value` on the resulting `Heartbeat_1_0` objects raises `AttributeError`.
+            # Subscribe with the real type instead of treating it as unstructured.
+            subscriber = self.client.node.make_subscriber(uavcan.node.Heartbeat_1_0, subject_id)
+            task = asyncio.create_task(
+                self._heartbeat_loop(state, subscriber),
+                name=f"pubwatch-heartbeat-{state.node_id}",
+            )
+        else:
+            subscriber = self.client.node.make_subscriber(uavcan.primitive.Unstructured_1, subject_id)
+            task = asyncio.create_task(
+                self._unstructured_loop(state, subject_id, subscriber),
+                name=f"pubwatch-unstructured-{state.node_id}-{subject_id}",
+            )
         state.unstructured_tasks[subject_id] = task
+
+    async def _heartbeat_loop(
+        self,
+        state: DeviceWatchState,
+        subscriber: pycyphal.presentation.Subscriber[Any],
+    ) -> None:
+        async for message, metadata in subscriber:
+            if self._stop_event.is_set():
+                return
+            if metadata.source_node_id != state.node_id:
+                continue
+
+            await self._record_message(
+                state=state,
+                port_name=self._resolve_port_name(state, HEARTBEAT_SUBJECT_ID),
+                subject_id=HEARTBEAT_SUBJECT_ID,
+                type_name="uavcan.node.Heartbeat.1.0",
+                fields=serialize_message(message),
+                transfer_id=getattr(metadata, "transfer_id", None),
+                parse_status="ok",
+            )
 
     async def _unstructured_loop(
         self,
@@ -498,13 +534,30 @@ class BusPublicationWatcher:
                 continue
 
             port_name = self._resolve_port_name(state, subject_id)
+            value = getattr(message, "value", None)
+            if value is None:
+                # Defensive fallback: some other subject unexpectedly shares a
+                # differently-typed subscriber (see the HEARTBEAT_SUBJECT_ID note in
+                # `_ensure_unstructured_subscription`). Serialize whatever we actually
+                # received instead of crashing on the missing `.value` attribute.
+                await self._record_message(
+                    state=state,
+                    port_name=port_name,
+                    subject_id=subject_id,
+                    type_name=type(message).__name__,
+                    fields=serialize_message(message),
+                    transfer_id=getattr(metadata, "transfer_id", None),
+                    parse_status="ok",
+                )
+                continue
+
             if subject_id in state.known_subject_ids:
                 parse_status = "missing_dsdl"
             else:
-                self._record_unknown(state.node_id, subject_id, byte_count=len(bytes(message.value)))
+                self._record_unknown(state.node_id, subject_id, byte_count=len(bytes(value)))
                 parse_status = "missing_dsdl"
 
-            raw = bytes(message.value)
+            raw = bytes(value)
             await self._record_message(
                 state=state,
                 port_name=port_name,

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -477,6 +477,81 @@ async def test_unstructured_loop_keeps_catalogued_port_name_without_dsdl() -> No
 
 
 @pytest.mark.asyncio
+async def test_ensure_unstructured_subscription_uses_typed_heartbeat_subscriber() -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+
+    await watcher._ensure_unstructured_subscription(state, HEARTBEAT_SUBJECT_ID)
+
+    client.node.make_subscriber.assert_called_once_with(uavcan.node.Heartbeat_1_0, HEARTBEAT_SUBJECT_ID)
+    task = state.unstructured_tasks[HEARTBEAT_SUBJECT_ID]
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_records_typed_heartbeat_message() -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+    subscriber = MagicMock()
+    metadata = SimpleNamespace(source_node_id=42, transfer_id=5)
+    heartbeat = uavcan.node.Heartbeat_1_0(
+        uptime=10,
+        health=uavcan.node.Health_1_0(0),
+        mode=uavcan.node.Mode_1_0(0),
+        vendor_specific_status_code=1,
+    )
+
+    async def _subscription() -> object:
+        yield heartbeat, metadata
+        watcher._stop_event.set()
+
+    subscriber.__aiter__ = lambda self: _subscription()
+    await watcher._heartbeat_loop(state, subscriber)
+
+    assert len(watcher.message_buffer) == 1
+    parsed = watcher.message_buffer[0]
+    assert parsed.subject_id == HEARTBEAT_SUBJECT_ID
+    assert parsed.type_name == "uavcan.node.Heartbeat.1.0"
+    assert parsed.parse_status == "ok"
+
+
+@pytest.mark.asyncio
+async def test_unstructured_loop_handles_unexpected_typed_message_without_crashing() -> None:
+    """Regression test: pycyphal shares one Subscriber impl per subject-ID regardless of
+    the requested dtype, so `_unstructured_loop` may receive an already-typed message (as
+    happened for HEARTBEAT_SUBJECT_ID before `_heartbeat_loop` existed) instead of
+    `Unstructured_1`. It must serialize defensively rather than crash on `message.value`.
+    """
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+    subscriber = MagicMock()
+    metadata = SimpleNamespace(source_node_id=42, transfer_id=1)
+    heartbeat = uavcan.node.Heartbeat_1_0(
+        uptime=1,
+        health=uavcan.node.Health_1_0(0),
+        mode=uavcan.node.Mode_1_0(0),
+        vendor_specific_status_code=0,
+    )
+
+    async def _subscription() -> object:
+        yield heartbeat, metadata
+        watcher._stop_event.set()
+
+    subscriber.__aiter__ = lambda self: _subscription()
+    await watcher._unstructured_loop(state, HEARTBEAT_SUBJECT_ID, subscriber)
+
+    assert len(watcher.message_buffer) == 1
+    parsed = watcher.message_buffer[0]
+    assert parsed.parse_status == "ok"
+    assert parsed.type_name == "Heartbeat_1_0"
+
+
+@pytest.mark.asyncio
 async def test_record_message_updates_stats_and_pending_queue() -> None:
     client = _mock_client()
     watcher = BusPublicationWatcher(client, max_messages=2)


### PR DESCRIPTION
## Summary

While investigating a report that a device did not reappear in the highdra-ui Monitor table after a `monitor.device_restart` (go dark -> appear), I found two compounding bugs in `BusPublicationWatcher`:

1. `_device_loop` had no exception handling around its per-tick reconciliation logic. Any unhandled exception there (e.g. while tearing down a node's subscriptions right as it goes dark) silently kills the loop's `asyncio.Task` for the rest of the watch session. Because the consuming runtime's "is running" flag is a separate lightweight task unrelated to this internal loop, a dead loop goes completely unnoticed -- the watcher keeps reporting itself as running while the tracked device list silently freezes.
2. That first fix's logging then surfaced the actual root cause live: `AttributeError: 'Heartbeat_1_0' object has no attribute 'value'`. `pycyphal`'s `Presentation.make_subscriber()` shares one `Subscriber` implementation per subject-ID regardless of the requested dtype. `Client`'s `NodeTracker` already subscribes to `uavcan.node.Heartbeat_1_0` on the fixed heartbeat subject, so `BusPublicationWatcher`'s own request for `Unstructured_1` on that same subject (to log heartbeat traffic outside the publication catalog) silently got back the existing typed subscriber instead. Accessing `.value` on those `Heartbeat_1_0` messages crashed the device's unstructured watch task -- invisibly, until something finally awaited it (e.g. `_teardown_device` on the next departure), at which point the exception used to propagate up and kill `_device_loop` itself (bug 1).

## Changes

* `_device_loop` now wraps each reconciliation tick in try/except, logging and retrying on the next poll instead of dying.
* Node departures now also call `on_state_changed`, matching the existing notifications for appearance/setup-completion.
* The heartbeat subject is now subscribed with its real `uavcan.node.Heartbeat_1_0` type via a dedicated `_heartbeat_loop`, instead of colliding with the shared typed subscriber under an `Unstructured_1` request.
* `_unstructured_loop` now defensively serializes any unexpectedly-typed message instead of assuming `.value` exists, in case another subject ever hits the same pycyphal sharing behavior.
* Added regression tests for the heartbeat subscription type and the defensive fallback; `CHANGELOG.md` updated under `Unreleased`.

## Test plan

- [x] `uv run pytest tests/test_publication_watch.py -q` -- 21 passed (3 new)
- [x] `uv run ruff check` / `ruff format --check` on changed files
- [x] Live verification against real hardware: reproduce a `monitor.device_restart` while a highdra-cli Monitor session is running and confirm the device reappears in the highdra-ui table without the `AttributeError` in the runner console