### PR TITLE
feat: presence-only publication watch with focus/unfocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * python-can-remote added as CAN transport interface
-* dependecies include python-can-remote and python-can[multicast] now
+* dependencies include python-can-remote and python-can[multicast] now
 
 ## [0.7.3] - 2026-07-09
 

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -357,8 +357,13 @@ class BusPublicationWatcher:
         # Refresh heartbeat/name metadata for nodes still online.
         for node_id, entry in entries.items():
             if node_id in self.devices:
-                self.devices[node_id].device_info = self._serialize_node_entry(node_id, entry)
-                self.last_bus_activity_unix = time.time()
+                previous_info = self.devices[node_id].device_info
+                new_info = self._serialize_node_entry(node_id, entry)
+                if self._heartbeat_activity_signature(previous_info) != self._heartbeat_activity_signature(
+                    new_info
+                ):
+                    self.last_bus_activity_unix = time.time()
+                self.devices[node_id].device_info = new_info
 
     async def focus(self, node_id: int) -> None:
         if node_id in self._focused_node_ids:
@@ -678,6 +683,7 @@ class BusPublicationWatcher:
             port_history = deque(maxlen=self.max_messages_per_port)
             self._port_message_history[history_key] = port_history
         port_history.append(parsed)
+        self.last_bus_activity_unix = time.time()
 
     def _record_unknown(self, node_id: int, subject_id: int, *, byte_count: int) -> None:
         node_stats = self.unknown_ports.setdefault(node_id, {})
@@ -687,6 +693,16 @@ class BusPublicationWatcher:
     def _notify_state_changed(self) -> None:
         if self._on_state_changed is not None:
             self._on_state_changed()
+
+    @staticmethod
+    def _heartbeat_activity_signature(device_info: dict[str, Any]) -> tuple[Any, ...]:
+        """Fields that indicate fresh heartbeat traffic when they change."""
+        return (
+            device_info.get("uptime_s"),
+            device_info.get("health"),
+            device_info.get("mode"),
+            device_info.get("vssc"),
+        )
 
     @staticmethod
     def _serialize_node_entry(node_id: int, entry: Any) -> dict[str, Any]:

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -359,9 +359,7 @@ class BusPublicationWatcher:
             if node_id in self.devices:
                 previous_info = self.devices[node_id].device_info
                 new_info = self._serialize_node_entry(node_id, entry)
-                if self._heartbeat_activity_signature(previous_info) != self._heartbeat_activity_signature(
-                    new_info
-                ):
+                if self._heartbeat_activity_signature(previous_info) != self._heartbeat_activity_signature(new_info):
                     self.last_bus_activity_unix = time.time()
                 self.devices[node_id].device_info = new_info
 

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -254,17 +254,23 @@ class BusPublicationWatcher:
         del self._pending_messages[:limit]
         return batch
 
-    def build_status_payload(self, *, message_limit: int | None = None) -> dict[str, Any]:
+    def build_status_payload(
+        self,
+        *,
+        message_limit: int | None = DEFAULT_NOTIFY_BATCH,
+        include_registry: bool = False,
+        include_message_history: bool = False,
+    ) -> dict[str, Any]:
         """Build a status snapshot."""
         devices_payload = []
         for state in sorted(self.devices.values(), key=lambda item: item.node_id):
-            devices_payload.append(
-                {
-                    **state.device_info,
-                    "publications": [port.to_dict() for port in state.publications.values()],
-                    "registry": state.registry_entries,
-                }
-            )
+            entry: dict[str, Any] = {
+                **state.device_info,
+                "publications": [port.to_dict() for port in state.publications.values()],
+            }
+            if include_registry:
+                entry["registry"] = state.registry_entries
+            devices_payload.append(entry)
 
         unknown_payload = []
         for node_id, ports in sorted(self.unknown_ports.items()):
@@ -279,14 +285,28 @@ class BusPublicationWatcher:
                     stats.to_dict(node_id=state.node_id, port_name=port_name, subject_id=subject_id)
                 )
 
-        return {
+        result: dict[str, Any] = {
             "devices": devices_payload,
             "messages": [message.to_dict() for message in self.drain_pending_messages(limit=message_limit)],
-            "message_history": self.build_message_history_payload(),
             "unknown_ports": unknown_payload,
             "port_stats": port_stats_payload,
             "updated_at_unix": time.time(),
         }
+        if include_message_history:
+            result["message_history"] = self.build_message_history_payload()
+        return result
+
+    def build_focus_status_payload(self, node_id: int) -> dict[str, Any]:
+        """Build a full status snapshot for one focused node."""
+        payload = self.build_status_payload(
+            include_registry=True,
+            include_message_history=True,
+            message_limit=None,
+        )
+        payload["message_history"] = [
+            item for item in payload.get("message_history", []) if item.get("node_id") == node_id
+        ]
+        return payload
 
     async def _device_loop(self) -> None:
         """Poll node tracker and reconcile watched devices with the current bus."""

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -112,8 +112,13 @@ class DeviceWatchState:
 class BusPublicationWatcher:
     """Watch Cyphal publications from multiple devices using one :class:`~cyphal_device_library.client.Client`.
 
-    The watcher polls :attr:`Client.node_tracker` for online nodes. For each new remote
-    node it:
+    The watcher polls :attr:`Client.node_tracker` for online nodes and registers each
+    new remote node for **presence only** (heartbeat/name metadata in
+    :attr:`devices`). Publication discovery and subscriptions start only after an
+    explicit :meth:`focus` call. :meth:`unfocus` tears down subscribers and clears
+    publication-derived state while keeping the presence row.
+
+    For a focused node, setup:
 
     1. Discovers ``uavcan.pub.<port_name>.{id,type,dt_ms}`` registers.
     2. Creates a :class:`~cyphal_device_library.device.Device` with the publication
@@ -306,7 +311,7 @@ class BusPublicationWatcher:
         current_ids = set(entries)
         known_ids = set(self.devices)
 
-        # New nodes: register immediately, then discover publications in parallel.
+        # New nodes: register presence only; call focus() to start publication setup.
         for node_id in current_ids - known_ids:
             if node_id == self.client.node.id:
                 continue
@@ -358,6 +363,8 @@ class BusPublicationWatcher:
         state.publications.clear()
         state.registry_entries = []
         state.port_stats.clear()
+        state.known_subject_ids.clear()
+        self.unknown_ports.pop(node_id, None)
         self._drop_port_message_history(node_id)
         self._notify_state_changed()
 

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -176,7 +176,13 @@ class BusPublicationWatcher:
         self._device_loop_task: asyncio.Task[None] | None = None
         self._promiscuous_task: asyncio.Task[None] | None = None
         self._setup_tasks: dict[int, asyncio.Task[None]] = {}
+        self._focused_node_ids: set[int] = set()
+        self.last_bus_activity_unix: float = 0.0
         self._lock = asyncio.Lock()
+
+    @property
+    def focused_node_ids(self) -> set[int]:
+        return set(self._focused_node_ids)
 
     @property
     def is_running(self) -> bool:
@@ -207,6 +213,7 @@ class BusPublicationWatcher:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
         self._setup_tasks.clear()
+        self._focused_node_ids.clear()
 
         async with self._lock:
             for state in list(self.devices.values()):
@@ -307,11 +314,12 @@ class BusPublicationWatcher:
             device_info = self._serialize_node_entry(node_id, entry)
             async with self._lock:
                 self.devices[node_id] = DeviceWatchState(node_id=node_id, device_info=device_info)
+            self.last_bus_activity_unix = time.time()
             self._notify_state_changed()
-            self._start_device_setup(node_id)
 
         # Departed nodes: cancel in-flight setup, subscribers, and cached state.
         for node_id in known_ids - current_ids:
+            self._focused_node_ids.discard(node_id)
             await self._cancel_device_setup(node_id)
             async with self._lock:
                 state = self.devices.pop(node_id, None)
@@ -325,6 +333,33 @@ class BusPublicationWatcher:
         for node_id, entry in entries.items():
             if node_id in self.devices:
                 self.devices[node_id].device_info = self._serialize_node_entry(node_id, entry)
+                self.last_bus_activity_unix = time.time()
+
+    async def focus(self, node_id: int) -> None:
+        if node_id in self._focused_node_ids:
+            return
+        state = self.devices.get(node_id)
+        if state is None:
+            return
+        self._focused_node_ids.add(node_id)
+        self._start_device_setup(node_id)
+        task = self._setup_tasks.get(node_id)
+        if task is not None:
+            await task
+
+    async def unfocus(self, node_id: int) -> None:
+        self._focused_node_ids.discard(node_id)
+        await self._cancel_device_setup(node_id)
+        state = self.devices.get(node_id)
+        if state is None:
+            return
+        await self._teardown_device(state)
+        # Keep presence row; clear publication-derived fields
+        state.publications.clear()
+        state.registry_entries = []
+        state.port_stats.clear()
+        self._drop_port_message_history(node_id)
+        self._notify_state_changed()
 
     def _start_device_setup(self, node_id: int) -> None:
         existing = self._setup_tasks.get(node_id)

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -195,6 +195,64 @@ async def test_device_loop_refreshes_existing_node_metadata(instant_sleep: None)
 
 
 @pytest.mark.asyncio
+async def test_reconcile_does_not_bump_bus_activity_for_stale_heartbeat(instant_sleep: None) -> None:
+    """Frozen heartbeat metadata must not refresh last_bus_activity_unix."""
+    client = _mock_client(node_id=1)
+    entry = _heartbeat_entry(uptime=10, vssc=5)
+    client.node_tracker.registry = {42: entry}
+    watcher = BusPublicationWatcher(client)
+    watcher.last_bus_activity_unix = 1000.0
+    watcher.devices[42] = DeviceWatchState(
+        node_id=42,
+        device_info=BusPublicationWatcher._serialize_node_entry(42, entry),
+    )
+
+    with patch("cyphal_device_library.publication_watch.time.time", return_value=2000.0):
+        await _run_device_loop_once(watcher)
+
+    assert watcher.last_bus_activity_unix == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_bumps_bus_activity_when_heartbeat_changes(instant_sleep: None) -> None:
+    client = _mock_client(node_id=1)
+    client.node_tracker.registry = {42: _heartbeat_entry(uptime=10, vssc=5)}
+    watcher = BusPublicationWatcher(client)
+    watcher.last_bus_activity_unix = 1000.0
+    watcher.devices[42] = DeviceWatchState(
+        node_id=42,
+        device_info=BusPublicationWatcher._serialize_node_entry(42, _heartbeat_entry(uptime=10, vssc=5)),
+    )
+
+    client.node_tracker.registry[42] = _heartbeat_entry(uptime=11, vssc=5)
+    with patch("cyphal_device_library.publication_watch.time.time", return_value=2000.0):
+        await _run_device_loop_once(watcher)
+
+    assert watcher.last_bus_activity_unix == 2000.0
+
+
+@pytest.mark.asyncio
+async def test_record_message_bumps_bus_activity(instant_sleep: None) -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    watcher.last_bus_activity_unix = 1000.0
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+
+    with patch("cyphal_device_library.publication_watch.time.time", return_value=2000.0):
+        await watcher._record_message(
+            state=state,
+            port_name="status",
+            subject_id=6060,
+            type_name="uavcan.primitive.Empty.1.0",
+            fields={},
+            transfer_id=1,
+            parse_status="ok",
+        )
+
+    assert watcher.last_bus_activity_unix == 2000.0
+
+
+@pytest.mark.asyncio
 async def test_device_loop_registers_devices_before_setup_completes(instant_sleep: None) -> None:
     client = _mock_client(node_id=1)
     client.node_tracker.registry = {

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -624,6 +624,72 @@ async def test_record_message_updates_stats_and_pending_queue() -> None:
     assert state.port_stats[6060].count == 3
 
 
+def test_build_status_payload_defaults_omit_registry_and_history() -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    state = DeviceWatchState(node_id=7, device_info={"node_id": 7, "name": "x"})
+    state.registry_entries = [{"name": "uavcan.node.id", "dtype": "natural8", "value": 7}]
+    state.publications = {
+        "bms_data": PublicationPort(
+            port_name="bms_data",
+            subject_id=100,
+            type_name="x",
+            dt_ms=None,
+            parse_status="ok",
+            message_type=None,
+        )
+    }
+    watcher.devices[7] = state
+    watcher._pending_messages.append(
+        ParsedMessage(
+            node_id=7,
+            port_name="bms_data",
+            subject_id=100,
+            type_name="x",
+            timestamp_unix=1.0,
+            transfer_id=1,
+            fields={"a": 1},
+            sequence=1,
+        )
+    )
+
+    payload = watcher.build_status_payload()
+
+    assert "registry" not in payload["devices"][0]
+    assert "message_history" not in payload
+    assert len(payload["messages"]) == 1
+
+
+def test_build_focus_status_payload_includes_registry_and_node_history() -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client, max_messages_per_port=3)
+    state = DeviceWatchState(node_id=7, device_info={"node_id": 7, "name": "x"})
+    state.registry_entries = [{"name": "uavcan.node.id", "dtype": "natural8", "value": 7}]
+    watcher.devices[7] = state
+    other = DeviceWatchState(node_id=8, device_info={"node_id": 8, "name": "y"})
+    watcher.devices[8] = other
+
+    for index, node_id in enumerate((7, 7, 8)):
+        asyncio.run(
+            watcher._record_message(
+                state=state if node_id == 7 else other,
+                port_name="temp_data",
+                subject_id=6061,
+                type_name="test.Type.1.0",
+                fields={"index": index},
+                transfer_id=index,
+                parse_status="ok",
+            )
+        )
+
+    payload = watcher.build_focus_status_payload(7)
+
+    assert payload["devices"][0]["registry"] == state.registry_entries
+    assert "message_history" in payload
+    assert all(item["node_id"] == 7 for item in payload["message_history"])
+    assert len(payload["messages"]) == 3
+
+
 def test_drain_pending_messages_and_build_status_payload() -> None:
     client = _mock_client()
     watcher = BusPublicationWatcher(client)
@@ -661,7 +727,7 @@ def test_drain_pending_messages_and_build_status_payload() -> None:
     assert payload["devices"][0]["node_id"] == 42
     assert payload["devices"][0]["publications"][0]["port_name"] == "status"
     assert payload["messages"][0]["port_name"] == "status"
-    assert payload["message_history"] == []
+    assert "message_history" not in payload
     assert payload["unknown_ports"][0]["node_id"] == 99
     assert payload["unknown_ports"][0]["subject_id"] == 8080
     assert payload["port_stats"][0]["count"] == 2
@@ -691,7 +757,7 @@ def test_build_status_payload_includes_per_subject_message_history() -> None:
             )
         )
 
-    payload = watcher.build_status_payload()
+    payload = watcher.build_status_payload(include_message_history=True)
     history = payload["message_history"]
     assert len(history) == 3
     assert [item["fields"]["index"] for item in history] == [1, 2, 3]

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -90,26 +90,65 @@ async def test_start_and_stop_lifecycle(instant_sleep: None) -> None:
 
 
 @pytest.mark.asyncio
+async def test_reconcile_does_not_auto_setup_publications(instant_sleep: None) -> None:
+    client = _mock_client()
+    client.node_tracker.registry = {42: _heartbeat_entry()}
+    watcher = BusPublicationWatcher(client)
+    with patch.object(watcher, "_setup_device", new_callable=AsyncMock) as setup:
+        await _run_device_loop_once(watcher)
+        setup.assert_not_called()
+    assert 42 in watcher.devices
+    assert watcher.devices[42].subscriber_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_focus_runs_setup_unfocus_tears_down_subscribers(instant_sleep: None) -> None:
+    client = _mock_client()
+    client.node_tracker.registry = {42: _heartbeat_entry()}
+    watcher = BusPublicationWatcher(client)
+    await _run_device_loop_once(watcher)
+
+    with (
+        patch(
+            "cyphal_device_library.publication_watch.discover_publication_ports_remote",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("cyphal_device_library.publication_watch.Device") as device_cls,
+        patch(
+            "cyphal_device_library.publication_watch.Registry",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "cyphal_device_library.publication_watch.registry_to_json_entries",
+            return_value=[],
+        ),
+    ):
+        device = MagicMock()
+        device.wait_for_initialization = AsyncMock()
+        device_cls.return_value = device
+        await watcher.focus(42)
+        assert 42 in watcher.focused_node_ids
+        device.wait_for_initialization.assert_awaited()
+
+        await watcher.unfocus(42)
+        assert 42 not in watcher.focused_node_ids
+        device.close.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_device_loop_adds_remote_nodes(instant_sleep: None) -> None:
     client = _mock_client(node_id=1)
     client.node_tracker.registry = {42: _heartbeat_entry()}
 
     watcher = BusPublicationWatcher(client)
-    setup_calls: list[int] = []
-
-    async def _setup_device(state: DeviceWatchState) -> None:
-        setup_calls.append(state.node_id)
-        state.device_info["setup"] = True
-
-    watcher._setup_device = _setup_device  # type: ignore[method-assign]
 
     await _run_device_loop_once(watcher)
-    await _await_device_setup_tasks(watcher)
 
-    assert setup_calls == [42]
     assert 42 in watcher.devices
     assert watcher.devices[42].device_info["node_id"] == 42
     assert watcher.devices[42].device_info["uptime_s"] == 10
+    assert watcher.devices[42].subscriber_tasks == {}
     assert 1 not in watcher.devices
 
 
@@ -179,11 +218,21 @@ async def test_device_loop_registers_devices_before_setup_completes(instant_slee
     assert 43 in watcher.devices
     assert watcher.devices[42].device_info["node_id"] == 42
     assert watcher.devices[43].device_info["node_id"] == 43
-    await _REAL_ASYNCIO_SLEEP(0)
+    assert setup_started == []
+
+    focus_tasks = [
+        asyncio.create_task(watcher.focus(42)),
+        asyncio.create_task(watcher.focus(43)),
+    ]
+    for _ in range(10):
+        await _REAL_ASYNCIO_SLEEP(0)
+        if sorted(setup_started) == [42, 43]:
+            break
+
     assert sorted(setup_started) == [42, 43]
 
     setup_release.set()
-    await _await_device_setup_tasks(watcher)
+    await asyncio.gather(*focus_tasks)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Make `BusPublicationWatcher` presence-only by default; start publication subscribers only via `focus(node_id)` / tear down with `unfocus`.
- Light default `build_status_payload` (no registry/`message_history`, capped incremental messages) plus `build_focus_status_payload` for focused snapshots.
- Track `last_bus_activity_unix` only on real heartbeat/message activity so consumers can detect frozen RX.

## Test plan
- [ ] `pytest tests/test_publication_watch.py -v`
- [ ] Confirm reconcile does not auto-setup publications until `focus`
- [ ] Confirm frozen heartbeat metadata does not advance `last_bus_activity_unix`


Made with [Cursor](https://cursor.com)