### PR TITLE
fix: warm catalog + fast focus without Device re-init

### DIFF
--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -1,4 +1,4 @@
-"""Bus-wide publication watching using Client and Device."""
+"""Bus-wide publication watching using Client and Registry discovery."""
 
 from __future__ import annotations
 
@@ -16,7 +16,6 @@ import uavcan.node
 import uavcan.primitive
 
 from .client import Client
-from .device import Device
 from .publications import PublicationPort, discover_publication_ports_remote
 from .registry import Registry, registry_to_json_entries
 from .util.message_serialize import ensure_json_serializable, serialize_message
@@ -107,7 +106,6 @@ class DeviceWatchState:
 
     node_id: int
     device_info: dict[str, Any]
-    device: Device | None = None
     publications: dict[str, PublicationPort] = field(default_factory=dict)
     subscriber_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     unstructured_tasks: dict[int, asyncio.Task[None]] = field(default_factory=dict)
@@ -115,6 +113,8 @@ class DeviceWatchState:
     known_subject_ids: set[int] = field(default_factory=set)
     registry_entries: list[dict[str, Any]] = field(default_factory=list)
     setup_task: asyncio.Task[None] | None = None
+    # Keep open typed subscribers so they are closed on teardown.
+    typed_subscribers: dict[str, pycyphal.presentation.Subscriber[Any]] = field(default_factory=dict)
 
 
 class BusPublicationWatcher:
@@ -129,11 +129,9 @@ class BusPublicationWatcher:
     For a focused node, setup:
 
     1. Discovers ``uavcan.pub.<port_name>.{id,type,dt_ms}`` registers.
-    2. Creates a :class:`~cyphal_device_library.device.Device` with the publication
-       registers pre-fetched.
-    3. Subscribes to each catalogued port via :meth:`Device.get_subscription` when the
+    2. Subscribes to each catalogued port via ``node.make_subscriber`` when the
        DSDL type is available locally, or via an unstructured subscriber otherwise.
-    4. Subscribes to :data:`uavcan.node.Heartbeat_1_0` on the fixed subject ID so
+    3. Subscribes to :data:`uavcan.node.Heartbeat_1_0` on the fixed subject ID so
        heartbeat traffic on non-catalogued ports can be observed.
 
     Received messages are stored in :attr:`message_buffer` and queued in an internal
@@ -442,6 +440,11 @@ class BusPublicationWatcher:
 
     async def _setup_device(self, state: DeviceWatchState) -> None:
         # List uavcan.pub.* registers and build the publication catalog.
+        # Do not construct a Device here: Device.__init__ re-fetches every
+        # publication register in an all-or-nothing TaskGroup. On busy nodes
+        # (e.g. motherboard at node-ID 0 with many pubs) a single refresh
+        # failure aborts init, errors are swallowed, and subscribers never
+        # start — while the catalog from this discovery still reaches the UI.
         registry = Registry(state.node_id, self.client.node.make_client)
         publications = await discover_publication_ports_remote(registry)
         if not self._device_still_active(state):
@@ -450,30 +453,6 @@ class BusPublicationWatcher:
         self._notify_state_changed()
         state.publications = {port.port_name: port for port in publications}
         state.known_subject_ids = {port.subject_id for port in publications}
-
-        # Pre-fetch only publication-related registers on the Device.
-        register_names: list[str] = []
-        for port in publications:
-            register_names.extend(
-                [
-                    f"uavcan.pub.{port.port_name}.id",
-                    f"uavcan.pub.{port.port_name}.type",
-                ]
-            )
-            if port.dt_ms is not None:
-                register_names.append(f"uavcan.pub.{port.port_name}.dt_ms")
-
-        device = Device(
-            self.client,
-            state.node_id,
-            discover_registers=register_names or False,
-            owns_client=False,
-        )
-        await device.wait_for_initialization(timeout=10.0)
-        if not self._device_still_active(state):
-            device.close()
-            return
-        state.device = device
 
         subscribed_subjects: set[int] = set()
         typed_by_subject: dict[int, PublicationPort] = {}
@@ -528,32 +507,59 @@ class BusPublicationWatcher:
                 await task
         state.unstructured_tasks.clear()
 
-        if state.device is not None:
-            state.device.close()
-            state.device = None
+        for subscriber in list(state.typed_subscribers.values()):
+            with contextlib.suppress(Exception):
+                subscriber.close()
+        state.typed_subscribers.clear()
 
     async def _subscriber_loop(self, state: DeviceWatchState, port: PublicationPort) -> None:
-        assert state.device is not None
         assert port.message_type is not None
         if not is_subscribable_subject_id(port.subject_id):
             return
 
-        subscriber = state.device.get_subscription(port.port_name)
-        async for message, metadata in subscriber:
-            if self._stop_event.is_set():
-                return
-            # Ignore transfers relayed from other nodes on the same subject ID.
-            if metadata.source_node_id != state.node_id:
-                continue
-            await self._record_message(
-                state=state,
-                port_name=port.port_name,
-                subject_id=port.subject_id,
-                type_name=port.type_name,
-                fields=serialize_message(message),
-                transfer_id=getattr(metadata, "transfer_id", None),
-                parse_status="ok",
+        try:
+            subscriber = self.client.node.make_subscriber(port.message_type, port.subject_id)
+        except Exception:
+            LOGGER.warning(
+                "Failed to subscribe to node %s port %s (subject %s)",
+                state.node_id,
+                port.port_name,
+                port.subject_id,
+                exc_info=True,
             )
+            return
+
+        state.typed_subscribers[port.port_name] = subscriber
+        try:
+            async for message, metadata in subscriber:
+                if self._stop_event.is_set():
+                    return
+                # Ignore transfers relayed from other nodes on the same subject ID.
+                # Use `is not None` so node-ID 0 is not treated as missing.
+                if metadata.source_node_id is None or metadata.source_node_id != state.node_id:
+                    continue
+                await self._record_message(
+                    state=state,
+                    port_name=port.port_name,
+                    subject_id=port.subject_id,
+                    type_name=port.type_name,
+                    fields=serialize_message(message),
+                    transfer_id=getattr(metadata, "transfer_id", None),
+                    parse_status="ok",
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            LOGGER.warning(
+                "Subscriber loop failed for node %s port %s",
+                state.node_id,
+                port.port_name,
+                exc_info=True,
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                subscriber.close()
+            state.typed_subscribers.pop(port.port_name, None)
 
     async def _ensure_unstructured_subscription(self, state: DeviceWatchState, subject_id: int) -> None:
         if subject_id in state.unstructured_tasks:
@@ -591,7 +597,7 @@ class BusPublicationWatcher:
         async for message, metadata in subscriber:
             if self._stop_event.is_set():
                 return
-            if metadata.source_node_id != state.node_id:
+            if metadata.source_node_id is None or metadata.source_node_id != state.node_id:
                 continue
 
             await self._record_message(
@@ -613,7 +619,7 @@ class BusPublicationWatcher:
         async for message, metadata in subscriber:
             if self._stop_event.is_set():
                 return
-            if metadata.source_node_id != state.node_id:
+            if metadata.source_node_id is None or metadata.source_node_id != state.node_id:
                 continue
 
             port_name = self._resolve_port_name(state, subject_id)

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -30,6 +30,7 @@ MAX_SUBJECT_ID = 8191
 DEFAULT_MAX_MESSAGES = 200
 DEFAULT_MAX_MESSAGES_PER_PORT = 50
 DEFAULT_NOTIFY_BATCH = 30
+CATALOG_DISCOVERY_STAGGER_S = 0.1
 
 
 def is_subscribable_subject_id(subject_id: int) -> bool:
@@ -189,6 +190,7 @@ class BusPublicationWatcher:
         self._device_loop_task: asyncio.Task[None] | None = None
         self._promiscuous_task: asyncio.Task[None] | None = None
         self._setup_tasks: dict[int, asyncio.Task[None]] = {}
+        self._catalog_tasks: dict[int, asyncio.Task[None]] = {}
         self._focused_node_ids: set[int] = set()
         self.last_bus_activity_unix: float = 0.0
         self._lock = asyncio.Lock()
@@ -437,7 +439,10 @@ class BusPublicationWatcher:
     def _device_still_active(self, state: DeviceWatchState) -> bool:
         return self.devices.get(state.node_id) is state
 
-    async def _setup_device(self, state: DeviceWatchState) -> None:
+    def _catalog_is_warm(self, state: DeviceWatchState) -> bool:
+        return bool(state.publications) or bool(state.registry_entries)
+
+    async def _discover_device_catalog(self, state: DeviceWatchState) -> None:
         # List uavcan.pub.* registers and build the publication catalog.
         # Do not construct a Device here: Device.__init__ re-fetches every
         # publication register in an all-or-nothing TaskGroup. On busy nodes
@@ -449,10 +454,22 @@ class BusPublicationWatcher:
         if not self._device_still_active(state):
             return
         state.registry_entries = registry_to_json_entries(registry)
-        self._notify_state_changed()
         state.publications = {port.port_name: port for port in publications}
         state.known_subject_ids = {port.subject_id for port in publications}
+        self._notify_state_changed()
 
+    async def _ensure_catalog(self, state: DeviceWatchState) -> None:
+        if self._catalog_is_warm(state):
+            return
+        catalog_task = self._catalog_tasks.get(state.node_id)
+        if catalog_task is not None and not catalog_task.done():
+            await catalog_task
+            if self._catalog_is_warm(state):
+                return
+        await self._discover_device_catalog(state)
+
+    async def _start_device_subscribers(self, state: DeviceWatchState) -> None:
+        publications = list(state.publications.values())
         subscribed_subjects: set[int] = set()
         typed_by_subject: dict[int, PublicationPort] = {}
         for port in publications:
@@ -485,6 +502,14 @@ class BusPublicationWatcher:
         # Observe heartbeat on the standard subject even when not in the pub catalog.
         if HEARTBEAT_SUBJECT_ID not in subscribed_subjects:
             await self._ensure_unstructured_subscription(state, HEARTBEAT_SUBJECT_ID)
+
+    async def _setup_device(self, state: DeviceWatchState) -> None:
+        await self._ensure_catalog(state)
+        if not self._device_still_active(state):
+            return
+        if state.node_id not in self._focused_node_ids:
+            return
+        await self._start_device_subscribers(state)
 
     async def _teardown_device(self, state: DeviceWatchState) -> None:
         if state.setup_task is not None and not state.setup_task.done():

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -122,16 +122,16 @@ class BusPublicationWatcher:
     """Watch Cyphal publications from multiple devices using one :class:`~cyphal_device_library.client.Client`.
 
     The watcher polls :attr:`Client.node_tracker` for online nodes and registers each
-    new remote node for **presence only** (heartbeat/name metadata in
-    :attr:`devices`). Publication discovery and subscriptions start only after an
-    explicit :meth:`focus` call. :meth:`unfocus` tears down subscribers and clears
-    live observation state (port stats, unknown ports, message history) while keeping
-    the publication catalog and registry entries. The presence row remains in
-    :attr:`devices`.
+    new remote node for **presence** (heartbeat/name metadata in :attr:`devices`) and
+    starts **background catalog discovery** (publication ports and registry entries).
+    Subscriptions start only after an explicit :meth:`focus` call. :meth:`unfocus`
+    tears down subscribers and clears live observation state (port stats, unknown
+    ports, message history) while keeping the publication catalog and registry
+    entries. The presence row remains in :attr:`devices`.
 
     For a focused node, setup:
 
-    1. Discovers ``uavcan.pub.<port_name>.{id,type,dt_ms}`` registers.
+    1. Ensures the publication catalog is warm (awaits in-flight discovery if needed).
     2. Subscribes to each catalogued port via ``node.make_subscriber`` when the
        DSDL type is available locally, or via an unstructured subscriber otherwise.
     3. Subscribes to :data:`uavcan.node.Heartbeat_1_0` on the fixed subject ID so
@@ -228,6 +228,10 @@ class BusPublicationWatcher:
             with contextlib.suppress(asyncio.CancelledError):
                 await task
         self._setup_tasks.clear()
+
+        for node_id in list(self._catalog_tasks):
+            await self._cancel_catalog_discovery(node_id)
+
         self._focused_node_ids.clear()
 
         async with self._lock:
@@ -341,8 +345,11 @@ class BusPublicationWatcher:
         current_ids = set(entries)
         known_ids = set(self.devices)
 
-        # New nodes: register presence only; call focus() to start publication setup.
-        for node_id in current_ids - known_ids:
+        # New nodes: register presence and start staggered catalog discovery.
+        # Call focus() to start subscribers.
+        new_nodes = sorted(current_ids - known_ids)
+        stagger_i = 0
+        for node_id in new_nodes:
             if node_id == self.client.node.id:
                 continue
             entry = entries[node_id]
@@ -351,11 +358,14 @@ class BusPublicationWatcher:
                 self.devices[node_id] = DeviceWatchState(node_id=node_id, device_info=device_info)
             self.last_bus_activity_unix = time.time()
             self._notify_state_changed()
+            self._start_catalog_discovery(node_id, stagger_index=stagger_i)
+            stagger_i += 1
 
-        # Departed nodes: cancel in-flight setup, subscribers, and cached state.
+        # Departed nodes: cancel in-flight setup/catalog, subscribers, and cached state.
         for node_id in known_ids - current_ids:
             self._focused_node_ids.discard(node_id)
             await self._cancel_device_setup(node_id)
+            await self._cancel_catalog_discovery(node_id)
             async with self._lock:
                 state = self.devices.pop(node_id, None)
             if state is not None:
@@ -441,6 +451,42 @@ class BusPublicationWatcher:
 
     def _catalog_is_warm(self, state: DeviceWatchState) -> bool:
         return bool(state.publications) or bool(state.registry_entries)
+
+    def _start_catalog_discovery(self, node_id: int, *, stagger_index: int = 0) -> None:
+        existing = self._catalog_tasks.get(node_id)
+        if existing is not None and not existing.done():
+            return
+        stagger_s = stagger_index * CATALOG_DISCOVERY_STAGGER_S
+        task = asyncio.create_task(
+            self._catalog_discovery_task(node_id, stagger_s),
+            name=f"pubwatch-catalog-{node_id}",
+        )
+        self._catalog_tasks[node_id] = task
+
+    async def _catalog_discovery_task(self, node_id: int, stagger_s: float) -> None:
+        try:
+            if stagger_s > 0:
+                await asyncio.sleep(stagger_s)
+            if self._stop_event.is_set():
+                return
+            state = self.devices.get(node_id)
+            if state is None or self._catalog_is_warm(state):
+                return
+            await self._discover_device_catalog(state)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            LOGGER.warning("Catalog discovery failed for node %s", node_id, exc_info=True)
+        finally:
+            self._catalog_tasks.pop(node_id, None)
+
+    async def _cancel_catalog_discovery(self, node_id: int) -> None:
+        task = self._catalog_tasks.pop(node_id, None)
+        if task is None:
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     async def _discover_device_catalog(self, state: DeviceWatchState) -> None:
         # List uavcan.pub.* registers and build the publication catalog.

--- a/src/cyphal_device_library/publication_watch.py
+++ b/src/cyphal_device_library/publication_watch.py
@@ -124,7 +124,9 @@ class BusPublicationWatcher:
     new remote node for **presence only** (heartbeat/name metadata in
     :attr:`devices`). Publication discovery and subscriptions start only after an
     explicit :meth:`focus` call. :meth:`unfocus` tears down subscribers and clears
-    publication-derived state while keeping the presence row.
+    live observation state (port stats, unknown ports, message history) while keeping
+    the publication catalog and registry entries. The presence row remains in
+    :attr:`devices`.
 
     For a focused node, setup:
 
@@ -388,11 +390,8 @@ class BusPublicationWatcher:
         if state is None:
             return
         await self._teardown_device(state)
-        # Keep presence row; clear publication-derived fields
-        state.publications.clear()
-        state.registry_entries = []
+        # Keep catalog/registry across unfocus; clear live observation only.
         state.port_stats.clear()
-        state.known_subject_ids.clear()
         self.unknown_ports.pop(node_id, None)
         self._drop_port_message_history(node_id)
         self._notify_state_changed()

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -363,6 +363,7 @@ async def test_setup_device_uses_typed_and_unstructured_subscriptions() -> None:
     ):
         state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
         watcher.devices[42] = state
+        watcher._focused_node_ids.add(42)
         await watcher._setup_device(state)
         await asyncio.sleep(0)
         for task in state.subscriber_tasks.values():
@@ -400,6 +401,7 @@ async def test_setup_device_does_not_construct_device_even_for_node_zero() -> No
     ):
         state = DeviceWatchState(node_id=0, device_info={"node_id": 0})
         watcher.devices[0] = state
+        watcher._focused_node_ids.add(0)
         await watcher._setup_device(state)
         await asyncio.sleep(0)
         for task in list(state.subscriber_tasks.values()):
@@ -440,6 +442,7 @@ async def test_setup_device_pushes_registry_snapshot() -> None:
     ):
         state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
         watcher.devices[42] = state
+        watcher._focused_node_ids.add(42)
         await watcher._setup_device(state)
         for task in state.subscriber_tasks.values():
             task.cancel()
@@ -518,6 +521,7 @@ async def test_setup_device_skips_unset_subject_ids_and_still_subscribes() -> No
     ):
         state = DeviceWatchState(node_id=0, device_info={"node_id": 0})
         watcher.devices[0] = state
+        watcher._focused_node_ids.add(0)
         await watcher._setup_device(state)
         for task in list(state.subscriber_tasks.values()):
             task.cancel()
@@ -950,3 +954,65 @@ async def test_unfocus_keeps_publications_and_registry() -> None:
     assert state.port_stats == {}
     assert 42 not in watcher.unknown_ports
     assert state.subscriber_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_focus_with_warm_catalog_skips_rediscovery() -> None:
+    client = _mock_client(node_id=1)
+    watcher = BusPublicationWatcher(client)
+    port = PublicationPort(
+        port_name="status",
+        subject_id=6060,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+    state = DeviceWatchState(
+        node_id=42,
+        device_info={"node_id": 42},
+        publications={"status": port},
+        registry_entries=[{"name": "uavcan.pub.status.id", "value": [6060]}],
+        known_subject_ids={6060},
+    )
+    watcher.devices[42] = state
+
+    with (
+        patch(
+            "cyphal_device_library.publication_watch.discover_publication_ports_remote",
+            AsyncMock(),
+        ) as discover,
+        patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()),
+    ):
+        await watcher.focus(42)
+        for task in list(state.subscriber_tasks.values()):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    discover.assert_not_awaited()
+    assert "status" in state.subscriber_tasks or client.node.make_subscriber.called
+
+
+@pytest.mark.asyncio
+async def test_discover_device_catalog_does_not_start_subscribers() -> None:
+    client = _mock_client(node_id=1)
+    watcher = BusPublicationWatcher(client)
+    port = PublicationPort(
+        port_name="status",
+        subject_id=6060,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+    watcher.devices[42] = state
+
+    with patch(
+        "cyphal_device_library.publication_watch.discover_publication_ports_remote",
+        AsyncMock(return_value=[port]),
+    ):
+        await watcher._discover_device_catalog(state)
+
+    assert state.publications == {"status": port}
+    assert state.subscriber_tasks == {}
+    assert state.unstructured_tasks == {}

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -114,7 +114,6 @@ async def test_focus_runs_setup_unfocus_tears_down_subscribers(instant_sleep: No
             new_callable=AsyncMock,
             return_value=[],
         ),
-        patch("cyphal_device_library.publication_watch.Device") as device_cls,
         patch(
             "cyphal_device_library.publication_watch.Registry",
             return_value=MagicMock(),
@@ -124,16 +123,11 @@ async def test_focus_runs_setup_unfocus_tears_down_subscribers(instant_sleep: No
             return_value=[],
         ),
     ):
-        device = MagicMock()
-        device.wait_for_initialization = AsyncMock()
-        device_cls.return_value = device
         await watcher.focus(42)
         assert 42 in watcher.focused_node_ids
-        device.wait_for_initialization.assert_awaited()
 
         await watcher.unfocus(42)
         assert 42 not in watcher.focused_node_ids
-        device.close.assert_called()
 
 
 @pytest.mark.asyncio
@@ -321,7 +315,6 @@ async def test_device_loop_notifies_when_device_is_registered(instant_sleep: Non
 async def test_stop_tears_down_watched_devices() -> None:
     client = _mock_client(node_id=1)
     watcher = BusPublicationWatcher(client)
-    mock_device = MagicMock()
 
     async def _hang_forever() -> None:
         await asyncio.Event().wait()
@@ -331,7 +324,6 @@ async def test_stop_tears_down_watched_devices() -> None:
     watcher.devices[42] = DeviceWatchState(
         node_id=42,
         device_info={"node_id": 42},
-        device=mock_device,
         subscriber_tasks={"status": hang_task},
     )
     watcher.unknown_ports[42] = {8080: PortStats()}
@@ -341,7 +333,6 @@ async def test_stop_tears_down_watched_devices() -> None:
     assert watcher.devices == {}
     assert watcher.unknown_ports == {}
     assert hang_task.cancelled() or hang_task.done()
-    mock_device.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -363,33 +354,61 @@ async def test_setup_device_uses_typed_and_unstructured_subscriptions() -> None:
         parse_status="missing_dsdl",
     )
 
-    mock_device = MagicMock()
-    mock_device.wait_for_initialization = AsyncMock()
-
     with (
         patch(
             "cyphal_device_library.publication_watch.discover_publication_ports_remote",
             AsyncMock(return_value=[typed_port, missing_port]),
         ),
-        patch("cyphal_device_library.publication_watch.Device", return_value=mock_device) as device_cls,
         patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()) as ensure_unstructured,
     ):
         state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
         watcher.devices[42] = state
         await watcher._setup_device(state)
+        await asyncio.sleep(0)
         for task in state.subscriber_tasks.values():
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
 
-    device_cls.assert_called_once()
-    assert device_cls.call_args.kwargs["owns_client"] is False
-    assert mock_device is state.device
     assert set(state.publications) == {"status", "custom"}
     assert "status" in state.subscriber_tasks
     assert "custom" not in state.subscriber_tasks
+    client.node.make_subscriber.assert_called()
     ensure_unstructured.assert_any_await(state, missing_port.subject_id)
     ensure_unstructured.assert_any_await(state, HEARTBEAT_SUBJECT_ID)
+
+
+@pytest.mark.asyncio
+async def test_setup_device_does_not_construct_device_even_for_node_zero() -> None:
+    """Node-ID 0 (motherboard) must not go through Device init re-fetch storm."""
+    client = _mock_client(node_id=126)
+    watcher = BusPublicationWatcher(client)
+    typed_port = PublicationPort(
+        port_name="DC_bus",
+        subject_id=6008,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+
+    with (
+        patch(
+            "cyphal_device_library.publication_watch.discover_publication_ports_remote",
+            AsyncMock(return_value=[typed_port]),
+        ),
+        patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()),
+    ):
+        state = DeviceWatchState(node_id=0, device_info={"node_id": 0})
+        watcher.devices[0] = state
+        await watcher._setup_device(state)
+        await asyncio.sleep(0)
+        for task in list(state.subscriber_tasks.values()):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    assert "DC_bus" in state.subscriber_tasks
+    client.node.make_subscriber.assert_called()
 
 
 @pytest.mark.asyncio
@@ -408,9 +427,6 @@ async def test_setup_device_pushes_registry_snapshot() -> None:
         parse_status="ok",
     )
 
-    mock_device = MagicMock()
-    mock_device.wait_for_initialization = AsyncMock()
-
     with (
         patch(
             "cyphal_device_library.publication_watch.discover_publication_ports_remote",
@@ -420,7 +436,6 @@ async def test_setup_device_pushes_registry_snapshot() -> None:
             "cyphal_device_library.publication_watch.registry_to_json_entries",
             return_value=[{"name": "uavcan.pub.status.id", "dtype": "natural16[1]", "value": [6060]}],
         ) as serialize_registry,
-        patch("cyphal_device_library.publication_watch.Device", return_value=mock_device),
         patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()),
     ):
         state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
@@ -428,7 +443,7 @@ async def test_setup_device_pushes_registry_snapshot() -> None:
         await watcher._setup_device(state)
         for task in state.subscriber_tasks.values():
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
 
     serialize_registry.assert_called_once()
@@ -437,7 +452,7 @@ async def test_setup_device_pushes_registry_snapshot() -> None:
 
 
 @pytest.mark.asyncio
-async def test_teardown_device_cancels_tasks_and_closes_device() -> None:
+async def test_teardown_device_cancels_tasks_and_closes_subscribers() -> None:
     client = _mock_client()
     watcher = BusPublicationWatcher(client)
 
@@ -446,14 +461,15 @@ async def test_teardown_device_cancels_tasks_and_closes_device() -> None:
 
     typed_task = asyncio.create_task(_hang_forever(), name="typed")
     unstructured_task = asyncio.create_task(_hang_forever(), name="unstructured")
-    mock_device = MagicMock()
+    typed_sub = MagicMock()
+    typed_sub.close = MagicMock()
 
     state = DeviceWatchState(
         node_id=42,
         device_info={"node_id": 42},
-        device=mock_device,
         subscriber_tasks={"status": typed_task},
         unstructured_tasks={HEARTBEAT_SUBJECT_ID: unstructured_task},
+        typed_subscribers={"status": typed_sub},
     )
 
     await watcher._teardown_device(state)
@@ -462,8 +478,8 @@ async def test_teardown_device_cancels_tasks_and_closes_device() -> None:
     assert unstructured_task.cancelled() or unstructured_task.done()
     assert state.subscriber_tasks == {}
     assert state.unstructured_tasks == {}
-    mock_device.close.assert_called_once()
-    assert state.device is None
+    typed_sub.close.assert_called_once()
+    assert state.typed_subscribers == {}
 
 
 @pytest.mark.asyncio
@@ -493,15 +509,11 @@ async def test_setup_device_skips_unset_subject_ids_and_still_subscribes() -> No
         parse_status="ok",
     )
 
-    mock_device = MagicMock()
-    mock_device.wait_for_initialization = AsyncMock()
-
     with (
         patch(
             "cyphal_device_library.publication_watch.discover_publication_ports_remote",
             AsyncMock(return_value=[unset_typed, unset_unstructured, ok_port]),
         ),
-        patch("cyphal_device_library.publication_watch.Device", return_value=mock_device),
         patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()) as ensure_unstructured,
     ):
         state = DeviceWatchState(node_id=0, device_info={"node_id": 0})
@@ -530,28 +542,24 @@ async def test_teardown_device_ignores_failed_subscriber_task_exceptions() -> No
     failed_task = asyncio.create_task(_fail_like_unset_port(), name="unset-port")
     await asyncio.sleep(0)
     assert failed_task.done()
-    mock_device = MagicMock()
 
     state = DeviceWatchState(
         node_id=0,
         device_info={"node_id": 0},
-        device=mock_device,
         subscriber_tasks={"timekeeper_status": failed_task},
     )
 
     await watcher._teardown_device(state)
 
     assert state.subscriber_tasks == {}
-    mock_device.close.assert_called_once()
-    assert state.device is None
+    assert state.typed_subscribers == {}
 
 
 @pytest.mark.asyncio
 async def test_subscriber_loop_records_matching_messages() -> None:
     client = _mock_client()
     watcher = BusPublicationWatcher(client)
-    mock_device = MagicMock()
-    state = DeviceWatchState(node_id=42, device_info={"node_id": 42}, device=mock_device)
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
     port = PublicationPort(
         port_name="status",
         subject_id=6060,
@@ -566,7 +574,7 @@ async def test_subscriber_loop_records_matching_messages() -> None:
         yield message, metadata
         watcher._stop_event.set()
 
-    mock_device.get_subscription.return_value = _subscription()
+    client.node.make_subscriber.return_value = _subscription()
     task = asyncio.create_task(watcher._subscriber_loop(state, port))
     await task
 
@@ -581,8 +589,7 @@ async def test_subscriber_loop_records_matching_messages() -> None:
 async def test_subscriber_loop_ignores_other_source_nodes() -> None:
     client = _mock_client()
     watcher = BusPublicationWatcher(client)
-    mock_device = MagicMock()
-    state = DeviceWatchState(node_id=42, device_info={"node_id": 42}, device=mock_device)
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
     port = PublicationPort(
         port_name="status",
         subject_id=6060,
@@ -596,7 +603,7 @@ async def test_subscriber_loop_ignores_other_source_nodes() -> None:
         yield uavcan.primitive.Empty_1_0(), metadata
         watcher._stop_event.set()
 
-    mock_device.get_subscription.return_value = _subscription()
+    client.node.make_subscriber.return_value = _subscription()
     await watcher._subscriber_loop(state, port)
 
     assert len(watcher.message_buffer) == 0

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -916,3 +916,37 @@ def test_serialize_node_entry_without_info() -> None:
     assert payload["vssc"] == 9
     assert payload["vssc_hex"] == "0x09"
     assert payload["name"] is None
+
+
+@pytest.mark.asyncio
+async def test_unfocus_keeps_publications_and_registry() -> None:
+    client = _mock_client()
+    watcher = BusPublicationWatcher(client)
+    port = PublicationPort(
+        port_name="status",
+        subject_id=6060,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+    state = DeviceWatchState(
+        node_id=42,
+        device_info={"node_id": 42},
+        publications={"status": port},
+        registry_entries=[{"name": "uavcan.pub.status.id", "value": [6060]}],
+        known_subject_ids={6060},
+        port_stats={6060: PortStats()},
+    )
+    watcher.devices[42] = state
+    watcher._focused_node_ids.add(42)
+    watcher.unknown_ports[42] = {9999: PortStats()}
+
+    await watcher.unfocus(42)
+
+    assert 42 not in watcher.focused_node_ids
+    assert state.publications == {"status": port}
+    assert state.registry_entries == [{"name": "uavcan.pub.status.id", "value": [6060]}]
+    assert state.known_subject_ids == {6060}
+    assert state.port_stats == {}
+    assert 42 not in watcher.unknown_ports
+    assert state.subscriber_tasks == {}

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -13,6 +13,7 @@ import uavcan.primitive
 from pycyphal.application.node_tracker import Entry
 
 from cyphal_device_library.publication_watch import (
+    CATALOG_DISCOVERY_STAGGER_S,
     HEARTBEAT_SUBJECT_ID,
     BusPublicationWatcher,
     DeviceWatchState,
@@ -56,8 +57,10 @@ async def _run_device_loop_once(watcher: BusPublicationWatcher) -> None:
     """Run one reconciliation pass then stop the watcher."""
 
     async def _sleep_and_stop(_duration: float) -> None:
-        watcher._stop_event.set()
+        # Yield first so background tasks started during reconcile (e.g. catalog
+        # discovery) can run before the loop is marked stopped.
         await _REAL_ASYNCIO_SLEEP(0)
+        watcher._stop_event.set()
 
     with patch("cyphal_device_library.publication_watch.asyncio.sleep", _sleep_and_stop):
         await watcher._device_loop()
@@ -66,6 +69,13 @@ async def _run_device_loop_once(watcher: BusPublicationWatcher) -> None:
 async def _await_device_setup_tasks(watcher: BusPublicationWatcher) -> None:
     """Wait for any in-flight per-device setup tasks."""
     tasks = list(watcher._setup_tasks.values())
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _await_catalog_tasks(watcher: BusPublicationWatcher) -> None:
+    """Wait for any in-flight catalog discovery tasks."""
+    tasks = list(watcher._catalog_tasks.values())
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -90,15 +100,50 @@ async def test_start_and_stop_lifecycle(instant_sleep: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reconcile_does_not_auto_setup_publications(instant_sleep: None) -> None:
+async def test_reconcile_starts_catalog_discovery_without_subscribers(instant_sleep: None) -> None:
     client = _mock_client()
     client.node_tracker.registry = {42: _heartbeat_entry()}
     watcher = BusPublicationWatcher(client)
-    with patch.object(watcher, "_setup_device", new_callable=AsyncMock) as setup:
+    discover = AsyncMock()
+
+    async def _discover(state: DeviceWatchState) -> None:
+        await discover(state)
+        state.publications["status"] = PublicationPort(
+            port_name="status",
+            subject_id=6060,
+            type_name="uavcan.primitive.Empty.1.0",
+            message_type=None,
+            parse_status="missing_dsdl",
+        )
+        state.registry_entries = [{"name": "uavcan.pub.status.id", "value": [6060]}]
+
+    with patch.object(watcher, "_discover_device_catalog", side_effect=_discover):
         await _run_device_loop_once(watcher)
-        setup.assert_not_called()
+        await _await_catalog_tasks(watcher)
+
+    discover.assert_awaited()
     assert 42 in watcher.devices
     assert watcher.devices[42].subscriber_tasks == {}
+    assert "status" in watcher.devices[42].publications
+
+
+@pytest.mark.asyncio
+async def test_reconcile_schedules_staggered_catalog_tasks(instant_sleep: None) -> None:
+    client = _mock_client(node_id=1)
+    client.node_tracker.registry = {42: _heartbeat_entry(), 43: _heartbeat_entry()}
+    watcher = BusPublicationWatcher(client)
+    delays: list[float] = []
+
+    def _start(node_id: int, *, stagger_index: int = 0) -> None:
+        delays.append(stagger_index * CATALOG_DISCOVERY_STAGGER_S)
+        # still create a no-op completed catalog fill so reconcile finishes cleanly
+        state = watcher.devices[node_id]
+        state.registry_entries = [{"name": "x"}]
+
+    with patch.object(watcher, "_start_catalog_discovery", side_effect=_start):
+        await _run_device_loop_once(watcher)
+
+    assert delays == [0.0, CATALOG_DISCOVERY_STAGGER_S]
 
 
 @pytest.mark.asyncio

--- a/tests/test_publication_watch.py
+++ b/tests/test_publication_watch.py
@@ -1039,6 +1039,89 @@ async def test_focus_with_warm_catalog_skips_rediscovery() -> None:
 
 
 @pytest.mark.asyncio
+async def test_focus_awaits_in_flight_catalog_then_subscribes() -> None:
+    client = _mock_client(node_id=1)
+    watcher = BusPublicationWatcher(client)
+    port = PublicationPort(
+        port_name="status",
+        subject_id=6060,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+    state = DeviceWatchState(node_id=42, device_info={"node_id": 42})
+    watcher.devices[42] = state
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_discover(s: DeviceWatchState) -> None:
+        started.set()
+        await release.wait()
+        s.publications = {"status": port}
+        s.registry_entries = [{"name": "uavcan.pub.status.id", "value": [6060]}]
+        s.known_subject_ids = {6060}
+
+    with (
+        patch.object(watcher, "_discover_device_catalog", side_effect=_slow_discover),
+        patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()),
+    ):
+        catalog_task = asyncio.create_task(watcher._catalog_discovery_task(42, 0.0))
+        watcher._catalog_tasks[42] = catalog_task
+        await started.wait()
+        focus_task = asyncio.create_task(watcher.focus(42))
+        await asyncio.sleep(0)
+        assert not focus_task.done()
+        release.set()
+        await focus_task
+        for task in list(state.subscriber_tasks.values()):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    assert "status" in state.publications
+    assert 42 in watcher.focused_node_ids
+
+
+@pytest.mark.asyncio
+async def test_refocus_starts_subscribers_from_cached_catalog() -> None:
+    client = _mock_client(node_id=1)
+    watcher = BusPublicationWatcher(client)
+    port = PublicationPort(
+        port_name="status",
+        subject_id=6060,
+        type_name="uavcan.primitive.Empty.1.0",
+        message_type=load_message_type("uavcan.primitive.Empty.1.0"),
+        parse_status="ok",
+    )
+    state = DeviceWatchState(
+        node_id=42,
+        device_info={"node_id": 42},
+        publications={"status": port},
+        registry_entries=[{"name": "uavcan.pub.status.id", "value": [6060]}],
+        known_subject_ids={6060},
+    )
+    watcher.devices[42] = state
+
+    with (
+        patch(
+            "cyphal_device_library.publication_watch.discover_publication_ports_remote",
+            AsyncMock(),
+        ) as discover,
+        patch.object(watcher, "_ensure_unstructured_subscription", AsyncMock()),
+    ):
+        await watcher.focus(42)
+        await watcher.unfocus(42)
+        assert state.publications  # still warm
+        await watcher.focus(42)
+        for task in list(state.subscriber_tasks.values()):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+
+    assert discover.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_discover_device_catalog_does_not_start_subscribers() -> None:
     client = _mock_client(node_id=1)
     watcher = BusPublicationWatcher(client)


### PR DESCRIPTION
## Summary
- Subscribe on focus via `make_subscriber` without constructing `Device` (fixes busy nodes / motherboard node-ID 0).
- Discover registry + publication catalog eagerly after presence (staggered); keep catalog across unfocus.
- Focus only starts subscribers and reuses/awaits the warm catalog for responsive modal reopen.

## Test plan
- [ ] `pytest tests/test_publication_watch.py -v`
- [ ] Open/close/reopen device modal — ports/registry appear without a full rediscovery wait on reopen
- [ ] Motherboard (node 0) shows live rates while focused


Made with [Cursor](https://cursor.com)